### PR TITLE
Improve Structure Generation

### DIFF
--- a/src/main/java/io/github/cornflower/mixin/LocateCommandMixin.java
+++ b/src/main/java/io/github/cornflower/mixin/LocateCommandMixin.java
@@ -31,6 +31,6 @@ public abstract class LocateCommandMixin {
     @Inject(method = "register", at = @At(value = "RETURN"))
     private static void onRegister(CommandDispatcher<ServerCommandSource> dispatcher, CallbackInfo info) {
         dispatcher.register(literal("locate").requires(source -> source.hasPermissionLevel(2))
-                .then(literal("Cornflower_Ruin").executes(ctx -> execute(ctx.getSource(), "cornflower_ruin"))));
+                .then(literal("Cornflower_Ruin").executes(ctx -> execute(ctx.getSource(), "Cornflower_Ruin"))));
     }
 }

--- a/src/main/java/io/github/cornflower/mixin/MixinDefaultBiomeFeatures.java
+++ b/src/main/java/io/github/cornflower/mixin/MixinDefaultBiomeFeatures.java
@@ -1,0 +1,19 @@
+package io.github.cornflower.mixin;
+
+import io.github.cornflower.world.feature.CornflowerWorldFeatures;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.DefaultBiomeFeatures;
+import net.minecraft.world.gen.GenerationStep;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@SuppressWarnings("unused")
+@Mixin(DefaultBiomeFeatures.class)
+public class MixinDefaultBiomeFeatures {
+    @Inject(at = @At("RETURN"), method = "addDefaultStructures")
+    private static void addDefaultStructures(Biome biome, CallbackInfo info) {
+        biome.addFeature(GenerationStep.Feature.SURFACE_STRUCTURES, CornflowerWorldFeatures.getConfiguredFeature(CornflowerWorldFeatures.RUIN_STRUCTURE));
+    }
+}

--- a/src/main/java/io/github/cornflower/world/feature/CornflowerRuinFeature.java
+++ b/src/main/java/io/github/cornflower/world/feature/CornflowerRuinFeature.java
@@ -13,13 +13,10 @@ import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockBox;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.source.BiomeAccess;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.feature.AbstractTempleFeature;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
 import net.minecraft.world.gen.feature.StructureFeature;
-
-import java.util.Random;
 
 public class CornflowerRuinFeature extends AbstractTempleFeature<DefaultFeatureConfig> {
 
@@ -47,11 +44,6 @@ public class CornflowerRuinFeature extends AbstractTempleFeature<DefaultFeatureC
         return 3;
     }
 
-    @Override
-    public boolean shouldStartAt(BiomeAccess biomeAccess, ChunkGenerator<?> chunkGenerator, Random random, int chunkZ, int i, Biome biome) {
-        return true;
-    }
-
     public static class RuinStructureStart extends StructureStart {
 
         public RuinStructureStart(StructureFeature<?> feature, int chunkX, int chunkZ, BlockBox box, int references, long l) {
@@ -65,7 +57,7 @@ public class CornflowerRuinFeature extends AbstractTempleFeature<DefaultFeatureC
             int z = chunkZ * 16;
             BlockPos startingPos = new BlockPos(x, 0, z);
             BlockRotation rotation = BlockRotation.values()[this.random.nextInt(BlockRotation.values().length)];
-            CornflowerRuinGenerator.addParts(structureManager, startingPos, rotation, this.children, this.random, defaultFeatureConfig);
+            CornflowerRuinGenerator.addParts(structureManager, startingPos, rotation, this.children, defaultFeatureConfig);
             this.setBoundingBoxFromChildren();
         }
     }

--- a/src/main/java/io/github/cornflower/world/feature/CornflowerRuinGenerator.java
+++ b/src/main/java/io/github/cornflower/world/feature/CornflowerRuinGenerator.java
@@ -27,7 +27,7 @@ import java.util.Random;
 public class CornflowerRuinGenerator {
     public static final Identifier id = new Identifier("cornflower:ruin");
 
-    public static void addParts(StructureManager structureManager, BlockPos blockPos, BlockRotation rotation, List<StructurePiece> pieces, Random random, DefaultFeatureConfig defaultFeatureConfig) {
+    public static void addParts(StructureManager structureManager, BlockPos blockPos, BlockRotation rotation, List<StructurePiece> pieces, DefaultFeatureConfig defaultFeatureConfig) {
         pieces.add(new CornflowerRuinGenerator.Piece(structureManager, id, blockPos, rotation));
     }
 
@@ -63,20 +63,22 @@ public class CornflowerRuinGenerator {
 
         public void setStructureData(StructureManager structureManager) {
             Structure structure_1 = structureManager.getStructureOrBlank(this.template);
-            StructurePlacementData structurePlacementData_1 = (new StructurePlacementData()).setRotation(this.rotation).setMirrored(BlockMirror.NONE).setPosition(pos).addProcessor(BlockIgnoreStructureProcessor.IGNORE_STRUCTURE_BLOCKS);
+            StructurePlacementData structurePlacementData_1 = (new StructurePlacementData()).setRotation(this.rotation).setMirrored(BlockMirror.NONE).addProcessor(BlockIgnoreStructureProcessor.IGNORE_STRUCTURE_BLOCKS);
             this.setStructureData(structure_1, this.pos, structurePlacementData_1);
         }
 
         @Override
         protected void handleMetadata(String s, BlockPos blockPos, IWorld iWorld, Random random, BlockBox blockBox) {
-
         }
 
         @Override
         public boolean generate(IWorld world, ChunkGenerator<?> generator, Random rand, BlockBox box, ChunkPos pos) {
-            int yHeight = world.getTopY(Heightmap.Type.WORLD_SURFACE_WG, this.pos.getX() + 8, this.pos.getZ() + 8);
+            int yHeight = world.getTopY(Heightmap.Type.WORLD_SURFACE_WG, this.pos.getX(), this.pos.getZ());
+            BlockPos oldPos = this.pos;
             this.pos = this.pos.add(0, yHeight - 1, 0);
-            return super.generate(world, generator, rand, box, pos);
+            boolean result = super.generate(world, generator, rand, box, pos);
+            this.pos = oldPos;
+            return result;
         }
     }
 }

--- a/src/main/java/io/github/cornflower/world/feature/CornflowerWorldFeatures.java
+++ b/src/main/java/io/github/cornflower/world/feature/CornflowerWorldFeatures.java
@@ -10,9 +10,9 @@ package io.github.cornflower.world.feature;
 import net.minecraft.structure.StructurePieceType;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.gen.GenerationStep;
-import net.minecraft.world.gen.decorator.ChanceDecoratorConfig;
 import net.minecraft.world.gen.decorator.Decorator;
+import net.minecraft.world.gen.decorator.DecoratorConfig;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
 import net.minecraft.world.gen.feature.DefaultFeatureConfig;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.FeatureConfig;
@@ -20,8 +20,8 @@ import net.minecraft.world.gen.feature.StructureFeature;
 
 public class CornflowerWorldFeatures {
     public static final StructurePieceType RUIN_PIECE = Registry.register(Registry.STRUCTURE_PIECE, "cornflower:ruin_piece", CornflowerRuinGenerator.Piece::new);
-    public static final StructureFeature<DefaultFeatureConfig> RUIN_FEATURE = Registry.register(Registry.FEATURE, "cornflower:ruin_feature", new CornflowerRuinFeature());
-    public static final StructureFeature<DefaultFeatureConfig> RUIN_STRUCTURE = Registry.register(Registry.STRUCTURE_FEATURE, "cornflower:ruin_structure", RUIN_FEATURE);
+    public static final StructureFeature<DefaultFeatureConfig> RUIN_STRUCTURE = Registry.register(Registry.STRUCTURE_FEATURE, "cornflower:ruin_structure", new CornflowerRuinFeature());
+    public static final StructureFeature<DefaultFeatureConfig> RUIN_FEATURE = Registry.register(Registry.FEATURE, "cornflower:ruin_feature", RUIN_STRUCTURE);
 
     public static void init() {
         Feature.STRUCTURES.put("cornflower_ruin", RUIN_FEATURE);
@@ -29,13 +29,11 @@ public class CornflowerWorldFeatures {
         for (Biome biome : Registry.BIOME) {
             if (biome.getCategory() == Biome.Category.TAIGA) {
                 biome.addStructureFeature(RUIN_STRUCTURE.configure(FeatureConfig.DEFAULT));
-                biome.addFeature(
-                        GenerationStep.Feature.SURFACE_STRUCTURES,
-                        RUIN_FEATURE.configure(FeatureConfig.DEFAULT)
-                                .createDecoratedFeature(
-                                        Decorator.CHANCE_PASSTHROUGH
-                                                .configure(new ChanceDecoratorConfig(32))));
             }
         }
+    }
+
+    public static ConfiguredFeature<?, ?> getConfiguredFeature(StructureFeature<DefaultFeatureConfig> feature) {
+        return feature.configure(FeatureConfig.DEFAULT).createDecoratedFeature(Decorator.NOPE.configure(DecoratorConfig.DEFAULT));
     }
 }

--- a/src/main/resources/cornflower.mixins.json
+++ b/src/main/resources/cornflower.mixins.json
@@ -1,18 +1,19 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "io.github.cornflower.mixin",
-  "compatibilityLevel": "JAVA_8",
-  "mixins": [
-    "CampfireBlockAccessor",
-    "CauldronBlockMixin",
-    "LocateCommandMixin",
-    "LootableContainerBlockEntityMixin"
-  ],
-  "client": [
-  "PlayerListEntryMixin"
-  ],
-  "injectors": {
-    "defaultRequire": 1
+    "required": true,
+    "minVersion": "0.8",
+    "package": "io.github.cornflower.mixin",
+    "compatibilityLevel": "JAVA_8",
+    "mixins": [
+        "CampfireBlockAccessor",
+        "CauldronBlockMixin",
+        "LocateCommandMixin",
+        "LootableContainerBlockEntityMixin",
+        "MixinDefaultBiomeFeatures"
+    ],
+    "client": [
+        "PlayerListEntryMixin"
+    ],
+    "injectors": {
+        "defaultRequire": 1
   }
 }


### PR DESCRIPTION
This fixes some issues with structure generation, here is how:

- ```Biome.addFeature``` must be called for all biome, so if a structure starts generating at the edge of a taiga it won't just cut off at the next biome.
    - This is why there is a mixin for ```DefaultBiomeFeatures``` to support modded biomes
- ```Biome.addStructureFeature``` must be called only for the biome you wish it to start spawning in
- ```StructureManager.setPosition``` breaks things, I'm not sure why, but it does
- To change structure distance override ```getSpacing``` and ```getSeperation``` in your feature, by default it is Desert temple spacing and seperation